### PR TITLE
configs: bootdelay: perf [RDK-1498] The "bootdelay" is set to 0 seconds to optimize the boot time

### DIFF
--- a/include/configs/x5.h
+++ b/include/configs/x5.h
@@ -430,7 +430,7 @@
 #define CONFIG_EXTRA_ENV_SETTINGS \
     ENV_MEM_LAYOUT_SETTINGS \
     RDK_UPDATE \
-    "bootdelay=1\0"                                                                     \
+    "bootdelay=0\0"                                                                     \
 	BOOTENV
 #else
 #define CONFIG_EXTRA_ENV_SETTINGS                                                       \


### PR DESCRIPTION
configs: bootdelay: perf [RDK-1498] The "bootdelay" is set to 0 seconds to optimize the boot time
